### PR TITLE
Update readme to indicate Chef 11 or later is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This cookbook provides LWRPs and recipes to install and configure different moni
 * Official Newrelic nrsysmond
 * MeetMe [newrelic-plugin-agent](https://github.com/MeetMe/newrelic-plugin-agent)
 
+This cookbook requires Chef 11 or later.
+
 ## Attributes
 
 ### server monitoring with nrsysmond


### PR DESCRIPTION
My testing leads me to believe this cookbook isn't going to work on earlier versions of Chef because of changes like CHEF-2903 and CHEF-3376. 

Under Chef 10.26.0 providers can't be loaded because the attributes they reference for default values aren't loaded in time.
