### PR TITLE
Add more Test Kitchen platforms to cover other platforms we claim to support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,27 @@ driver_config:
   require_chef_omnibus: true
 
 platforms:
+- name: centos-6.4
+  driver_config:
+    box: opscode-centos-6.4
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
+- name: centos-5.9
+  driver_config:
+    box: opscode-centos-5.9
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_centos-5.9_provisionerless.box
+- name: fedora-18
+  driver_config:
+    box: opscode-fedora-18
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode-fedora-18_provisionerless.box
+- name: fedora-19
+  driver_config:
+    box: opscode-fedora-19
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode-fedora-19_provisionerless.box
+- name: debian-710
+  driver_config:
+    box: opscode-debian-7.1.0
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_debian-7.1.0_provisionerless.box
+    run_list: recipe[apt]
 - name: ubuntu-12.04
   driver_config:
     box: opscode-ubuntu-12.04


### PR DESCRIPTION
Since we claim to support Centos, Fedora, RHEL, Amazon, Debian, etc. in the metadata, let's add them to our Test Kitchen config. Also adding apt::default recipe to the run list for Ubuntu and Debian platforms, to ensure our apt cache is up-to-date.
