### PR TITLE
the generic-agent suites do not work without ruby

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,6 +44,7 @@ suites:
 
 - name: generic-agent-default
   run_list:
+  - recipe[ruby::1.9.1]
   - recipe[minitest-handler]
   - recipe[newrelic-ng::generic-agent-default]
   attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,5 @@ metadata
 
 group :integration do
   cookbook 'minitest-handler'
+  cookbook 'ruby'
 end


### PR DESCRIPTION
the opscode vm's dont have ruby, and the generic-agent test suites wont run without it
