### PR TITLE
use updated user and group attributes when creating plugin directories

### DIFF
--- a/recipes/plugin-agent-install.rb
+++ b/recipes/plugin-agent-install.rb
@@ -40,8 +40,8 @@ end
   node['newrelic-ng']['plugin-agent']['logfile'] ].each do |dir|
 
   directory ::File.dirname(dir) do
-    owner node['newrelic-ng']['plugin-agent']['user']
-    group node['newrelic-ng']['plugin-agent']['group']
+    owner node['newrelic-ng']['user']['name']
+    group node['newrelic-ng']['user']['group']
     mode  00755
   end
 end


### PR DESCRIPTION
old attrs = nil, causes service startup to fail because agent cannot write to directories
