### PR TITLE
Move user creation out of providers and into recipes

### DIFF
--- a/providers/generic_agent.rb
+++ b/providers/generic_agent.rb
@@ -28,13 +28,6 @@ def install_agent
   package 'gzip'  if new_resource.source  =~ /\.(tgz|gz)$/
   package 'bzip2' if new_resource.source  =~ /\.bz2$/
 
-  newrelic_ng_user 'default' do
-    name   new_resource.name
-    group  new_resource.group
-    shell  new_resource.shell
-    system new_resource.system
-  end
-
   target = "#{new_resource.target_dir}/#{new_resource.name}"
 
   directory target do

--- a/recipes/generic-agent-default.rb
+++ b/recipes/generic-agent-default.rb
@@ -19,6 +19,13 @@
 #
 
 node['newrelic-ng']['generic-agent']['agents'].each do |name, keys|
+
+  newrelic_ng_user node['newrelic-ng']['user']['name'] do
+    group node['newrelic-ng']['user']['group']
+    shell node['newrelic-ng']['user']['shell']
+    system node['newrelic-ng']['user']['system']
+  end
+
   newrelic_ng_generic_agent node['newrelic-ng']['license_key'] do
     name   name
     source keys[:source]

--- a/recipes/plugin-agent-install.rb
+++ b/recipes/plugin-agent-install.rb
@@ -18,6 +18,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+newrelic_ng_user node['newrelic-ng']['user']['name'] do
+  group node['newrelic-ng']['user']['group']
+  shell node['newrelic-ng']['user']['shell']
+  system node['newrelic-ng']['user']['system']
+end
+
 # a compiler is required for building some of the python modules the agent requires
 include_recipe 'build-essential'
 include_recipe 'python'
@@ -25,13 +31,6 @@ include_recipe 'python'
 python_pip 'newrelic-plugin-agent' do
   package_name node['newrelic-ng']['plugin-agent']['pip_package']
   action :install
-end
-
-newrelic_ng_user 'default' do
-  name   node['newrelic-ng']['user']['name']
-  group  node['newrelic-ng']['user']['group']
-  shell  node['newrelic-ng']['user']['shell']
-  system node['newrelic-ng']['user']['system']
 end
 
 # create config/run/log directories


### PR DESCRIPTION
The plugin-agent service fails to start when users aren't created before we try to set same user/group as owner of log and pid directories
