### PR TITLE
generic-agent service resources fail to start under Chef::Provider::Service::Init::Redhat

### DIFF
--- a/providers/generic_agent.rb
+++ b/providers/generic_agent.rb
@@ -86,6 +86,7 @@ def configure_agent
   daemon = "#{new_resource.target_dir}/#{new_resource.plugin_name}/newrelic_#{new_resource.plugin_name.split('_').first}_agent.daemon"
 
   service "newrelic_plugin_#{new_resource.plugin_name}" do
+    provider        Chef::Provider::Service::Simple
     supports        status: true
     start_command   "su #{new_resource.owner} -c '#{daemon} start'"
     stop_command    "su #{new_resource.owner} -c '#{daemon} stop'"


### PR DESCRIPTION
Output from generic-agent-default-centos-64 test-kitchen run:

```
       ================================================================================
       Error executing action `restart` on resource 'service[newrelic_plugin_nginx_status_agent]'
       ================================================================================


       Chef::Exceptions::Service
       -------------------------
       service[newrelic_plugin_nginx_status_agent]: unable to locate the init.d script!


       Resource Declaration:
       ---------------------
       # In /tmp/kitchen-chef-solo/cookbooks/newrelic-ng/providers/generic_agent.rb

        88:   service "newrelic_plugin_#{new_resource.plugin_name}" do
        89:     supports        status: true
        90:     start_command   "su #{new_resource.owner} -c '#{daemon} start'"
        91:     stop_command    "su #{new_resource.owner} -c '#{daemon} stop'"
        92:     status_command  "su #{new_resource.owner} -c '#{daemon} status'"
        93:
        94:     subscribes      :restart, "template[#{config_file}]"
        95:     action          :start
        96:   end
        97: end



       Compiled Resource:
       ------------------
       # Declared in /tmp/kitchen-chef-solo/cookbooks/newrelic-ng/providers/generic_agent.rb:88:in `configure_agent'

       service("newrelic_plugin_nginx_status_agent") do
         action [:start]
         supports {:status=>true}
         retries 0
         retry_delay 2
         service_name "newrelic_plugin_nginx_status_agent"
         pattern "newrelic_plugin_nginx_status_agent"
         start_command "su newrelic -c '/opt/newrelic-agents/nginx_status_agent/newrelic_nginx_agent.daemon start'"
         stop_command "su newrelic -c '/opt/newrelic-agents/nginx_status_agent/newrelic_nginx_agent.daemon stop'"
         status_command "su newrelic -c '/opt/newrelic-agents/nginx_status_agent/newrelic_nginx_agent.daemon status'"
         startup_type :automatic
         cookbook_name :"newrelic-ng"
       end



       [2013-09-09T19:56:43+00:00] ERROR: Running exception handlers
       [2013-09-09T19:56:43+00:00] ERROR: Exception handlers complete
       [2013-09-09T19:56:43+00:00] FATAL: Stacktrace dumped to /tmp/kitchen-chef-solo/cache/chef-stacktrace.out
       Chef Client failed. 18 resources updated
       [2013-09-09T19:56:43+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit
code 1)
```
