### PR TITLE
Add an optional agent name

### DIFF
--- a/attributes/plugin-agent.rb
+++ b/attributes/plugin-agent.rb
@@ -26,3 +26,4 @@ default['newrelic-ng']['plugin-agent']['service_config'] = ''
 default['newrelic-ng']['plugin-agent']['config_file'] = '/etc/newrelic/newrelic-plugin-agent.cfg'
 default['newrelic-ng']['plugin-agent']['mode'] = 00640
 default['newrelic-ng']['plugin-agent']['pip_package'] = 'newrelic-plugin-agent'
+default['newrelic-ng']['plugin-agent']['agent_name'] = 'default'

--- a/resources/plugin_agent.rb
+++ b/resources/plugin_agent.rb
@@ -26,6 +26,7 @@ attribute :poll_interval,  kind_of: Integer, default: node['newrelic-ng']['plugi
 attribute :pidfile,        kind_of: String,  default: node['newrelic-ng']['plugin-agent']['pidfile']
 attribute :logfile,        kind_of: String,  default: node['newrelic-ng']['plugin-agent']['logfile']
 attribute :service_config, kind_of: String,  default: node['newrelic-ng']['plugin-agent']['service_config']
+attribute :agent_name,     kind_of: String,  default: node['newrelic-ng']['plugin-agent']['default_agent_name']
 
 attribute :owner,          kind_of: String, default: node['newrelic-ng']['user']['name']
 attribute :group,          kind_of: String, default: node['newrelic-ng']['user']['group']

--- a/templates/default/plugin-agent-init-rhel.erb
+++ b/templates/default/plugin-agent-init-rhel.erb
@@ -11,9 +11,6 @@
 # Application
 APP="/usr/bin/newrelic-plugin-agent"
 
-# PID File
-PID_FILE="/var/run/newrelic/newrelic-plugin-agent.pid"
-
 # Additional arguments
 OPTS=""
 
@@ -30,7 +27,10 @@ if [ ! -f "${CONF}" ]; then
   failure $"cannot find newrelic-plugin-agent configuration file: '${CONF}'"
   echo
   exit 1
-fi
+  fi
+
+# PID File
+PIDFILE=$(sed -n -e 's/^[ ]*pidfile[ ]*:[ ]*//p' -e 's/[ ]*$//' ${CONF})
 
 OPTS="-c ${CONF} ${OPTS}"
 


### PR DESCRIPTION
The main reason to add an agent name is if you have multiple cookbooks/recipes
that are each trying to configure the plugin agent for a specific component, the
current approach of using a string for the configuration file doesn't compose
very well. The agent name allows you to configure multiple instances of the
plugin to run; you pay a _little_ bit more in memory consumption, but get a lot
more flexibility.

Note that once you're running multiple agents, you need to have unique log,
pid, init, and config files for them, otherwise things will get wonky real
fast. So unless they're either defaulted or set explicitly, the name will be
generated based the agent name.

Refactored configure action so the process is clearer.