### PR TITLE
Set newrelic-install to run in silent mode.

### DIFF
--- a/recipes/php-agent-install.rb
+++ b/recipes/php-agent-install.rb
@@ -33,6 +33,7 @@ end
 # waits until php agent is installed first
 execute 'newrelic-install' do
   command 'newrelic-install install'
+  environment ({'NR_INSTALL_SILENT' => '1'})
   action :nothing
   notifies :restart, "service[#{node['newrelic-ng']['app_monitoring']['php-agent']['server_service_name']}]", :delayed
 end


### PR DESCRIPTION
When run without NR_INSTALL_SILENT, the install
acts differently for RHEL7 compared to 6.

On RHEL6, since /bin is not symlinked to /usr/bin,
only 1 instance of php is found, so a prompt 
question doesn’t get asked.

On RHEL7, /bin is symlinked to /usr/bin, 2 instances
of php are found, so a prompt that doesn’t accept
no answer is displayed. This leads to a never ending
question prompt that eats up CPU.

Setting NR_INSTALL_SILENT environment variable
sorts this out.
