### PR TITLE
Ofir perturhska/issue 33 php "external" mode issue - tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vagrant
 Berksfile.lock
 Gemfile.lock
+.ruby-version
 *~
 *#
 .#*

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -95,3 +95,36 @@ suites:
       # This key seems to be valid somehow, further information:
       # https://github.com/chr4-cookbooks/newrelic-ng/issues/14
       license_key: 1234567890123456789012345678901234567890
+
+- name: php-external-default
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[apache2]
+  - recipe[newrelic-ng::php-agent-default]
+  attributes:
+    apache:
+      default_modules:
+      - status
+      - alias
+      - auth_basic
+      - authn_file
+      - authz_groupfile
+      - authz_host
+      - authz_user
+      - dir
+      - env
+      - mime
+      - setenvif
+      - deflate
+      - expires
+      - headers
+      - log_config
+      - logio
+      - php5
+    newrelic-ng:
+      # This key seems to be valid somehow, further information:
+      # https://github.com/chr4-cookbooks/newrelic-ng/issues/14
+      license_key: 1234567890123456789012345678901234567890
+      app_monitoring:
+        php-agent:
+          startup_mode: external

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,8 @@ platforms:
   run_list: recipe[yum]
 - name: centos-7.2
   run_list: recipe[yum]
+- name: ubuntu-12.04
+  run_list: recipe[apt]
 - name: ubuntu-14.04
   run_list: recipe[apt]
 - name: ubuntu-16.04

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,13 +10,13 @@ MethodLength:
 AbcSize:
   Enabled: false
 
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 
 Documentation:
   Enabled: false
 
-TrailingComma:
+TrailingCommaInLiteral:
     EnforcedStyleForMultiline: comma
 
 # Ignore snake_case filename warnings for now

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ Documentation:
 TrailingCommaInLiteral:
     EnforcedStyleForMultiline: comma
 
+TrailingCommaInArguments:
+    EnforcedStyleForMultiline: comma
+
 # Ignore snake_case filename warnings for now
 Style/FileName:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm:
+  - 2.2.4
+cache:
+  bundler: true
+  directories:
+    - tmp/rubocop_cache
+sudo: false
+env:
+  matrix:
+    - TASK='rubocop'
+script: bundle exec rake $TASK

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ group :integration do
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
 end
+
+group :development, :test do
+  gem 'rake'
+  gem 'rubocop'
+end

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/chr4-cookbooks/newrelic-ng.svg?branch=master)](https://travis-ci.org/chr4-cookbooks/newrelic-ng)
 # newrelic-ng Cookbook
 
 This cookbook provides LWRPs and recipes to install and configure different monitoring services for Newrelic.

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,6 @@
 
 desc 'Run rubocop'
 task :rubocop do
+  sh 'rubocop --version'
   sh 'rubocop --display-cop-names'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+#!/usr/bin/env rake
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
+desc 'Run rubocop'
+task :rubocop do
+  sh 'rubocop --display-cop-names'
+end

--- a/attributes/generic-agent.rb
+++ b/attributes/generic-agent.rb
@@ -20,7 +20,7 @@
 
 default['newrelic-ng']['generic-agent']['ruby-packages'] = value_for_platform_family(
   'rhel' => %w(ruby ruby-devel rubygems),
-  'debian' => %w(ruby ruby-dev)
+  'debian' => %w(ruby ruby-dev),
 )
 
 default['newrelic-ng']['generic-agent']['url'] = nil

--- a/attributes/generic-agent.rb
+++ b/attributes/generic-agent.rb
@@ -20,7 +20,7 @@
 
 default['newrelic-ng']['generic-agent']['ruby-packages'] = value_for_platform_family(
   'rhel' => %w(ruby ruby-devel rubygems),
-  'debian' => %w(ruby ruby-dev),
+  'debian' => %w(ruby ruby-dev)
 )
 
 default['newrelic-ng']['generic-agent']['url'] = nil

--- a/attributes/nrsysmond.rb
+++ b/attributes/nrsysmond.rb
@@ -34,7 +34,7 @@ default['newrelic-ng']['nrsysmond']['config'] = {
 }
 
 default['newrelic-ng']['nrsysmond']['config_file'] = '/etc/newrelic/nrsysmond.cfg'
-default['newrelic-ng']['nrsysmond']['mode'] = 00640
+default['newrelic-ng']['nrsysmond']['mode'] = 0o640
 
 default['newrelic-ng']['nrsysmond']['rpm']['repo']['url'] = "http://download.newrelic.com/pub/newrelic/el5/#{node['newrelic-ng']['arch']}/newrelic-repo-5-3.noarch.rpm"
 default['newrelic-ng']['nrsysmond']['rpm']['repo']['package'] = 'newrelic-repo'

--- a/attributes/nrsysmond.rb
+++ b/attributes/nrsysmond.rb
@@ -36,7 +36,7 @@ default['newrelic-ng']['nrsysmond']['config'] = {
 default['newrelic-ng']['nrsysmond']['config_file'] = '/etc/newrelic/nrsysmond.cfg'
 default['newrelic-ng']['nrsysmond']['mode'] = 00640
 
-default['newrelic-ng']['nrsysmond']['rpm']['repo']['url'] =  "http://download.newrelic.com/pub/newrelic/el5/#{node['newrelic-ng']['arch']}/newrelic-repo-5-3.noarch.rpm"
+default['newrelic-ng']['nrsysmond']['rpm']['repo']['url'] = "http://download.newrelic.com/pub/newrelic/el5/#{node['newrelic-ng']['arch']}/newrelic-repo-5-3.noarch.rpm"
 default['newrelic-ng']['nrsysmond']['rpm']['repo']['package'] = 'newrelic-repo'
 
 default['newrelic-ng']['nrsysmond']['apt']['repo']['url'] = 'http://apt.newrelic.com/debian/'

--- a/attributes/plugin-agent.rb
+++ b/attributes/plugin-agent.rb
@@ -24,5 +24,5 @@ default['newrelic-ng']['plugin-agent']['logfile'] = '/var/log/newrelic/newrelic-
 default['newrelic-ng']['plugin-agent']['service_config'] = ''
 
 default['newrelic-ng']['plugin-agent']['config_file'] = '/etc/newrelic/newrelic-plugin-agent.cfg'
-default['newrelic-ng']['plugin-agent']['mode'] = 00640
+default['newrelic-ng']['plugin-agent']['mode'] = 0o640
 default['newrelic-ng']['plugin-agent']['pip_package'] = 'newrelic-plugin-agent'

--- a/files/default/tests/minitest/php-agent-default_test.rb
+++ b/files/default/tests/minitest/php-agent-default_test.rb
@@ -31,12 +31,22 @@ describe 'newrelic-ng::php-agent-default' do
     service('newrelic-daemon').must_be_running
   end
 
-  it 'disables the New Relic daemon from startup init' do
-    service('newrelic-daemon').wont_be_enabled
-  end
+  if node['newrelic-ng']['app_monitoring']['php-agent']['startup_mode'] == 'agent'
+    it 'disables the New Relic daemon from startup init' do
+      service('newrelic-daemon').wont_be_enabled
+    end
 
-  it 'removes the New Relic daemon config' do
-    file(node['newrelic-ng']['app_monitoring']['daemon']['config_file']).wont_exist
+    it 'removes the New Relic daemon config' do
+      file(node['newrelic-ng']['app_monitoring']['daemon']['config_file']).wont_exist
+    end
+  else
+    it 'disables the New Relic daemon from startup init' do
+      service('newrelic-daemon').must_be_enabled
+    end
+
+    it 'removes the New Relic daemon config' do
+      file(node['newrelic-ng']['app_monitoring']['daemon']['config_file']).must_exist
+    end
   end
 
   it 'removes the New Relic upgrade.key' do

--- a/files/default/tests/minitest/php-agent-default_test.rb
+++ b/files/default/tests/minitest/php-agent-default_test.rb
@@ -50,5 +50,4 @@ describe 'newrelic-ng::php-agent-default' do
   it 'sets license key' do
     file(node['newrelic-ng']['app_monitoring']['php-agent']['config_file']).must_include('1234567890123456789012345678901234567890')
   end
-
 end

--- a/providers/generic_agent.rb
+++ b/providers/generic_agent.rb
@@ -44,7 +44,7 @@ def install_agent
   target = "#{new_resource.target_dir}/#{new_resource.plugin_name}"
 
   directory target do
-    mode      00755
+    mode      0o755
     recursive true
   end
 
@@ -79,7 +79,7 @@ def configure_agent
   r = template config_file do
     owner     new_resource.owner
     group     new_resource.group
-    mode      00644
+    mode      0o644
     source    'generic-agent.yml.erb'
     cookbook  'newrelic-ng'
     variables license_key: new_resource.license_key,

--- a/providers/php_agent.rb
+++ b/providers/php_agent.rb
@@ -19,7 +19,6 @@
 #
 
 action :configure do
-
   service 'newrelic-daemon' do
     supports status: true, start: true, stop: true, restart: true
   end
@@ -94,5 +93,4 @@ action :configure do
   end
 
   new_resource.updated_by_last_action(true) if php_config.updated_by_last_action?
-
 end

--- a/providers/php_agent.rb
+++ b/providers/php_agent.rb
@@ -57,7 +57,7 @@ action :configure do
     # configure proxy daemon settings
     daemon_config = template new_resource.daemon_config_file do
       cookbook  new_resource.cookbook
-      source    new_resource.source
+      source    new_resource.source_cfg
       owner     new_resource.owner
       group     new_resource.group
       mode      new_resource.mode

--- a/providers/plugin_agent.rb
+++ b/providers/plugin_agent.rb
@@ -19,7 +19,6 @@
 #
 
 action :configure do
-
   # postgresql and pgbouner need pg_config
   if new_resource.service_config.include?('postgresql:') ||
      new_resource.service_config.include?('pgbouncer:')
@@ -55,6 +54,6 @@ action :configure do
   service 'newrelic-plugin-agent' do
     supports   status: true, restart: true
     subscribes :restart, "template[#{new_resource.config_file}]"
-    action   [:enable, :start]
+    action     [:enable, :start]
   end
 end

--- a/recipes/plugin-agent-install.rb
+++ b/recipes/plugin-agent-install.rb
@@ -38,7 +38,6 @@ end
 [node['newrelic-ng']['plugin-agent']['config_file'],
  node['newrelic-ng']['plugin-agent']['pidfile'],
  node['newrelic-ng']['plugin-agent']['logfile']].each do |dir|
-
   directory ::File.dirname(dir) do
     owner node['newrelic-ng']['user']['name']
     group node['newrelic-ng']['user']['group']
@@ -48,7 +47,7 @@ end
 
 init_script_template = value_for_platform_family(
   rhel:   'plugin-agent-init-rhel.erb',
-  debian: 'plugin-agent-init-deb.erb',
+  debian: 'plugin-agent-init-deb.erb'
 )
 
 # deploy initscript

--- a/recipes/plugin-agent-install.rb
+++ b/recipes/plugin-agent-install.rb
@@ -47,7 +47,7 @@ end
 
 init_script_template = value_for_platform_family(
   rhel:   'plugin-agent-init-rhel.erb',
-  debian: 'plugin-agent-init-deb.erb'
+  debian: 'plugin-agent-init-deb.erb',
 )
 
 # deploy initscript

--- a/recipes/plugin-agent-install.rb
+++ b/recipes/plugin-agent-install.rb
@@ -41,7 +41,7 @@ end
   directory ::File.dirname(dir) do
     owner node['newrelic-ng']['user']['name']
     group node['newrelic-ng']['user']['group']
-    mode  00755
+    mode  0o755
   end
 end
 
@@ -52,7 +52,7 @@ init_script_template = value_for_platform_family(
 
 # deploy initscript
 template '/etc/init.d/newrelic-plugin-agent' do
-  mode      00755
+  mode      0o755
   cookbook  'newrelic-ng'
   source    init_script_template
   variables config_file: node['newrelic-ng']['plugin-agent']['config_file'],

--- a/resources/php_agent.rb
+++ b/resources/php_agent.rb
@@ -26,7 +26,7 @@ attribute :group,          kind_of: String, default: node['root_group']
 attribute :shell,          kind_of: String, default: node['newrelic-ng']['user']['shell']
 attribute :system,         kind_of: [TrueClass, FalseClass], default: node['newrelic-ng']['user']['system']
 
-attribute :mode,           kind_of: [Integer, String], default: 00644
+attribute :mode,           kind_of: [Integer, String], default: 0o644
 
 attribute :cookbook,       kind_of: String, default: 'newrelic-ng'
 attribute :source,         kind_of: String, default: 'newrelic.ini.php.erb'

--- a/resources/php_agent.rb
+++ b/resources/php_agent.rb
@@ -30,6 +30,7 @@ attribute :mode,           kind_of: [Integer, String], default: 00644
 
 attribute :cookbook,       kind_of: String, default: 'newrelic-ng'
 attribute :source,         kind_of: String, default: 'newrelic.ini.php.erb'
+attribute :source_cfg,     kind_of: String, default: 'newrelic.cfg.erb'
 
 attribute :license_key,    kind_of: String, name_attribute: true
 


### PR DESCRIPTION
Sorry it's a bit all in one, please review by commit.

Relates to issue https://github.com/chr4-cookbooks/newrelic-ng/issues/33

* Add  a test for the issue in question check by kitchen as:
bundle exec kitchen test php-external-default-ubuntu-12
(please don't ask why we still use ubuntu-12.04)
* Updates .rubocop
* Fixes to comply with current rubocop
* Travis-ci rubocop test integration. (probably needs a few key presses on your side to get right, login&enable repo) 
* Fixes to mini tests for 'external' php mode