### PR TITLE
Ofir petrushka/cookbook name depends

### DIFF
--- a/providers/generic_agent.rb
+++ b/providers/generic_agent.rb
@@ -82,7 +82,7 @@ def configure_agent
     group     new_resource.group
     mode      0o644
     source    'generic-agent.yml.erb'
-    cookbook  'newrelic-ng'
+    cookbook  cookbook_name
     variables license_key: new_resource.license_key,
               plugin_name: new_resource.plugin_name,
               config:      new_resource.config

--- a/providers/nrsysmond.rb
+++ b/providers/nrsysmond.rb
@@ -29,7 +29,7 @@ action :configure do
 
   r = template 'nrsysmond.cfg' do
     path      new_resource.config_file
-    cookbook  new_resource.cookbook
+    cookbook  cookbook_name
     source    new_resource.source
     owner     new_resource.owner
     group     new_resource.group

--- a/providers/php_agent.rb
+++ b/providers/php_agent.rb
@@ -56,7 +56,7 @@ action :configure do
 
     # configure proxy daemon settings
     daemon_config = template new_resource.daemon_config_file do
-      cookbook  new_resource.cookbook
+      cookbook  cookbook_name
       source    new_resource.source_cfg
       owner     new_resource.owner
       group     new_resource.group
@@ -82,7 +82,7 @@ action :configure do
   # (documented at /usr/lib/newrelic-php5/scripts/newrelic.ini.template)
   # and restart the web server in order to pick up the new settings
   php_config = template new_resource.config_file do
-    cookbook  new_resource.cookbook
+    cookbook  cookbook_name
     source    new_resource.source
     owner     new_resource.owner
     group     new_resource.group

--- a/providers/plugin_agent.rb
+++ b/providers/plugin_agent.rb
@@ -36,7 +36,7 @@ action :configure do
   python_pip 'newrelic_plugin_agent[postgresql]' if new_resource.service_config.include? 'postgresql:'
 
   r = template new_resource.config_file do
-    cookbook  new_resource.cookbook
+    cookbook  cookbook_name
     source    new_resource.source
     owner     new_resource.owner
     group     new_resource.group

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,4 +18,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-include_recipe 'newrelic-ng::nrsysmond-default'
+include_recipe cookbook_name + '::nrsysmond-default'

--- a/recipes/nrsysmond-default.rb
+++ b/recipes/nrsysmond-default.rb
@@ -18,6 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-include_recipe 'newrelic-ng::nrsysmond-install'
+include_recipe cookbook_name + '::nrsysmond-install'
 
 newrelic_ng_nrsysmond node['newrelic-ng']['license_key']

--- a/recipes/nrsysmond-install.rb
+++ b/recipes/nrsysmond-install.rb
@@ -18,6 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-include_recipe 'newrelic-ng::newrelic-repository'
+include_recipe cookbook_name + '::newrelic-repository'
 
 package 'newrelic-sysmond'

--- a/recipes/php-agent-default.rb
+++ b/recipes/php-agent-default.rb
@@ -18,6 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-include_recipe 'newrelic-ng::php-agent-install'
+include_recipe cookbook_name + '::php-agent-install'
 
 newrelic_ng_php_agent node['newrelic-ng']['license_key']

--- a/recipes/php-agent-install.rb
+++ b/recipes/php-agent-install.rb
@@ -19,7 +19,7 @@
 #
 
 include_recipe 'php'
-include_recipe 'newrelic-ng::newrelic-repository'
+include_recipe cookbook_name + '::newrelic-repository'
 
 # An older version (3.0) had a bug in the init scripts that when it
 # shut down the daemon it would also kill dpkg as it was trying to upgrade

--- a/recipes/plugin-agent-default.rb
+++ b/recipes/plugin-agent-default.rb
@@ -18,6 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-include_recipe 'newrelic-ng::plugin-agent-install'
+include_recipe cookbook_name + '::plugin-agent-install'
 
 newrelic_ng_plugin_agent node['newrelic-ng']['license_key']

--- a/recipes/plugin-agent-install.rb
+++ b/recipes/plugin-agent-install.rb
@@ -53,7 +53,7 @@ init_script_template = value_for_platform_family(
 # deploy initscript
 template '/etc/init.d/newrelic-plugin-agent' do
   mode      0o755
-  cookbook  'newrelic-ng'
+  cookbook  cookbook_name
   source    init_script_template
   variables config_file: node['newrelic-ng']['plugin-agent']['config_file'],
             user:        node['newrelic-ng']['user']['name'],

--- a/resources/nrsysmond.rb
+++ b/resources/nrsysmond.rb
@@ -34,9 +34,9 @@ attribute :timeout,        kind_of: Integer, default: node['newrelic-ng']['nrsys
 attribute :hostname,       kind_of: String,  default: node['newrelic-ng']['nrsysmond']['config']['hostname']
 attribute :labels,         kind_of: String,  default: node['newrelic-ng']['nrsysmond']['config']['labels']
 
+attribute :mode,           kind_of: [Integer, String], default: node['newrelic-ng']['nrsysmond']['mode']
 attribute :owner,          kind_of: String,  default: 'root'
 attribute :group,          kind_of: String,  default: node['newrelic-ng']['user']['group']
 attribute :config_file,    kind_of: String,  default: node['newrelic-ng']['nrsysmond']['config_file']
-attribute :mode,           kind_of: [Integer, String], default: node['newrelic-ng']['nrsysmond']['mode']
 
 attribute :source,         kind_of: String,  default: 'nrsysmond.cfg.erb'

--- a/resources/nrsysmond.rb
+++ b/resources/nrsysmond.rb
@@ -39,5 +39,4 @@ attribute :group,          kind_of: String,  default: node['newrelic-ng']['user'
 attribute :config_file,    kind_of: String,  default: node['newrelic-ng']['nrsysmond']['config_file']
 attribute :mode,           kind_of: [Integer, String], default: node['newrelic-ng']['nrsysmond']['mode']
 
-attribute :cookbook,       kind_of: String,  default: 'newrelic-ng'
 attribute :source,         kind_of: String,  default: 'nrsysmond.cfg.erb'

--- a/resources/php_agent.rb
+++ b/resources/php_agent.rb
@@ -28,7 +28,6 @@ attribute :system,         kind_of: [TrueClass, FalseClass], default: node['newr
 
 attribute :mode,           kind_of: [Integer, String], default: 0o644
 
-attribute :cookbook,       kind_of: String, default: 'newrelic-ng'
 attribute :source,         kind_of: String, default: 'newrelic.ini.php.erb'
 attribute :source_cfg,     kind_of: String, default: 'newrelic.cfg.erb'
 

--- a/resources/plugin_agent.rb
+++ b/resources/plugin_agent.rb
@@ -27,10 +27,10 @@ attribute :pidfile,        kind_of: String,  default: node['newrelic-ng']['plugi
 attribute :logfile,        kind_of: String,  default: node['newrelic-ng']['plugin-agent']['logfile']
 attribute :service_config, kind_of: String,  default: node['newrelic-ng']['plugin-agent']['service_config']
 
-attribute :owner,          kind_of: String, default: node['newrelic-ng']['user']['name']
-attribute :group,          kind_of: String, default: node['newrelic-ng']['user']['group']
-attribute :shell,          kind_of: String, default: node['newrelic-ng']['user']['shell']
-attribute :config_file,    kind_of: String, default: node['newrelic-ng']['plugin-agent']['config_file']
+attribute :owner,          kind_of: String,  default: node['newrelic-ng']['user']['name']
+attribute :group,          kind_of: String,  default: node['newrelic-ng']['user']['group']
+attribute :shell,          kind_of: String,  default: node['newrelic-ng']['user']['shell']
+attribute :config_file,    kind_of: String,  default: node['newrelic-ng']['plugin-agent']['config_file']
 attribute :source,         kind_of: String,  default: 'plugin-agent.yaml.erb'
 attribute :mode,           kind_of: [Integer, String], default: node['newrelic-ng']['plugin-agent']['mode']
 attribute :system,         kind_of: [TrueClass, FalseClass], default: node['newrelic-ng']['user']['system']

--- a/resources/plugin_agent.rb
+++ b/resources/plugin_agent.rb
@@ -31,7 +31,6 @@ attribute :owner,          kind_of: String, default: node['newrelic-ng']['user']
 attribute :group,          kind_of: String, default: node['newrelic-ng']['user']['group']
 attribute :shell,          kind_of: String, default: node['newrelic-ng']['user']['shell']
 attribute :config_file,    kind_of: String, default: node['newrelic-ng']['plugin-agent']['config_file']
-attribute :cookbook,       kind_of: String,  default: 'newrelic-ng'
 attribute :source,         kind_of: String,  default: 'plugin-agent.yaml.erb'
 attribute :mode,           kind_of: [Integer, String], default: node['newrelic-ng']['plugin-agent']['mode']
 attribute :system,         kind_of: [TrueClass, FalseClass], default: node['newrelic-ng']['user']['system']


### PR DESCRIPTION
Use cookbook_name over hardcoding the cookbook name 'newrelic-ng'
