### PR TITLE
run kitchen tests on travis

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,0 +1,3 @@
+---
+driver:
+  name: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,53 @@ cache:
   bundler: true
   directories:
     - tmp/rubocop_cache
-sudo: false
+sudo: true
 env:
+  global:
+    - KITCHEN_LOCAL_YAML=.kitchen.docker.yml
   matrix:
-    - TASK='rubocop'
-    - TASK='foodcritic'
-script: bundle exec rake $TASK
+    - TASK='rake rubocop'
+    - TASK='rake foodcritic'
+    - TASK='kitchen test nrsysmond-default-ubuntu-1204'
+    - TASK='kitchen test plugin-agent-default-ubuntu-1204'
+    - TASK='kitchen test generic-agent-default-ubuntu-1204'
+    - TASK='kitchen test php-agent-default-ubuntu-1204'
+    - TASK='kitchen test php-external-default-ubuntu-1204'
+    - TASK='kitchen test nrsysmond-default-ubuntu-1404'
+    - TASK='kitchen test plugin-agent-default-ubuntu-1404'
+    - TASK='kitchen test generic-agent-default-ubuntu-1404'
+    - TASK='kitchen test php-agent-default-ubuntu-1404'
+    - TASK='kitchen test php-external-default-ubuntu-1404'
+    - TASK='kitchen test nrsysmond-default-ubuntu-1604'
+    - TASK='kitchen test plugin-agent-default-ubuntu-1604'
+    - TASK='kitchen test generic-agent-default-ubuntu-1604'
+    - TASK='kitchen test php-agent-default-ubuntu-1604'
+    - TASK='kitchen test php-external-default-ubuntu-1604'
+    - TASK='kitchen test nrsysmond-default-debian-79'
+    - TASK='kitchen test plugin-agent-default-debian-79'
+    - TASK='kitchen test generic-agent-default-debian-79'
+    - TASK='kitchen test php-agent-default-debian-79'
+    - TASK='kitchen test php-external-default-debian-79'
+    - TASK='kitchen test nrsysmond-default-debian-84'
+    - TASK='kitchen test plugin-agent-default-debian-84'
+    - TASK='kitchen test generic-agent-default-debian-84'
+    - TASK='kitchen test php-agent-default-debian-84'
+    - TASK='kitchen test php-external-default-debian-84'
+    - TASK='kitchen test nrsysmond-default-centos-67'
+    - TASK='kitchen test plugin-agent-default-centos-67'
+    - TASK='kitchen test generic-agent-default-centos-67'
+    - TASK='kitchen test php-agent-default-centos-67'
+    - TASK='kitchen test php-external-default-centos-67'
+    - TASK='kitchen test nrsysmond-default-centos-72'
+    - TASK='kitchen test plugin-agent-default-centos-72'
+    - TASK='kitchen test generic-agent-default-centos-72'
+    - TASK='kitchen test php-agent-default-centos-72'
+    - TASK='kitchen test php-external-default-centos-72'
+
+before_script:
+- source <(curl -sL https://raw.githubusercontent.com/zuazo/kitchen-in-travis/0.5.0/scripts/start_docker.sh)
+
+script:
+- bundle exec $TASK
+
+after_failure: cat docker_daemon.log

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ gem 'berkshelf'
 
 group :integration do
   gem 'test-kitchen'
+end
+
+group :vagrant do
+  gem 'vagrant-wrapper'
   gem 'kitchen-vagrant'
 end
 
@@ -11,4 +15,8 @@ group :development, :test do
   gem 'rake'
   gem 'rubocop'
   gem 'foodcritic'
+end
+
+group :docker do
+  gem 'kitchen-docker', '~> 2.1.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -33,3 +33,41 @@ def prepare_foodcritic_sandbox(sandbox)
   cp_r Dir.glob("{#{files.join(',')}}"), sandbox
   puts "\n\n"
 end
+
+desc 'Run Test Kitchen integration tests'
+namespace :integration do
+  # Gets a collection of instances.
+  #
+  # @param regexp [String] regular expression to match against instance names.
+  # @param config [Hash] configuration values for the `Kitchen::Config` class.
+  # @return [Collection<Instance>] all instances.
+  def kitchen_instances(regexp, config)
+    instances = Kitchen::Config.new(config).instances
+    return instances if regexp.nil? || regexp == 'all'
+    instances.get_all(Regexp.new(regexp))
+  end
+
+  # Runs a test kitchen action against some instances.
+  #
+  # @param action [String] kitchen action to run (defaults to `'test'`).
+  # @param regexp [String] regular expression to match against instance names.
+  # @param loader_config [Hash] loader configuration options.
+  # @return void
+  def run_kitchen(action, regexp, loader_config = {})
+    action = 'test' if action.nil?
+    require 'kitchen'
+    Kitchen.logger = Kitchen.default_file_logger
+    config = { loader: Kitchen::Loader::YAML.new(loader_config) }
+    kitchen_instances(regexp, config).each { |i| i.send(action) }
+  end
+
+  desc 'Run integration tests with kitchen-vagrant'
+  task :vagrant, [:regexp, :action] do |_t, args|
+    run_kitchen(args.action, args.regexp)
+  end
+
+  desc 'Run integration tests with kitchen-docker'
+  task :docker, [:regexp, :action] do |_t, args|
+    run_kitchen(args.action, args.regexp, local_config: '.kitchen.docker.yml')
+  end
+end


### PR DESCRIPTION
This will make all current kitchen test run in travis in parallel (while still running rubocop and foodcritic) 

@chr4 I know you mentioned wanting to see a way for this to work.

This will be red in travis as there are things to fix for some of the suites and/or platforms and/or combo of which. (So merging red in hopes to fix or differing merge until can fix all issues is up to you..)
I will not currently have the time to continue hacking on this in the short term, but I hope this will be useful even if just to trigger @jeffbyrnes to do it in a better way ;).

What we would have wanted to see is a more dynamic way for travis to do the platform X kitchen suite, but it seems this isn't currently supported.
The only way to keep the list dynamically is not to use Travis parallel execution which would result in much longer run times. (current ones are quite long as well for the free usage tier which seems to run a max of 5 jobs at the time of test). 

@jeffbyrnes I'd admit a lot of the code, including this, uses Gems and Rakefile because that's what I found to re-use ;). (path of least resistance)
This is based on zuazo/kitchen-in-travis as you can easily see in the travis file.
